### PR TITLE
BottomSheet 디자인 디테일 수정

### DIFF
--- a/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/NavigationPlayground.kt
+++ b/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/NavigationPlayground.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
@@ -123,9 +124,10 @@ private fun DuckieLogo() {
         QuackImage(
             src = team.duckie.quackquack.ui.R.drawable.quack_duckie_text_logo,
             overrideSize = DpSize(
-                width = 72.dp,
-                height = 24.dp,
+                width = 66.dp,
+                height = 16.dp,
             ),
+            contentScale = ContentScale.FillHeight,
         )
     }
 }

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/bottomSheet.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/bottomSheet.kt
@@ -37,8 +37,8 @@ import team.duckie.quackquack.ui.modifier.applyQuackSize
 import team.duckie.quackquack.ui.modifier.quackClickable
 
 private val BottomSheetShape = RoundedCornerShape(
-    topStart = 12.dp,
-    topEnd = 12.dp,
+    topStart = 16.dp,
+    topEnd = 16.dp,
 )
 
 private val QuackBottomSheetHandleSize = DpSize(

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/bottomSheet.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/bottomSheet.kt
@@ -37,8 +37,8 @@ import team.duckie.quackquack.ui.modifier.applyQuackSize
 import team.duckie.quackquack.ui.modifier.quackClickable
 
 private val BottomSheetShape = RoundedCornerShape(
-    topStart = 24.dp,
-    topEnd = 24.dp,
+    topStart = 12.dp,
+    topEnd = 12.dp,
 )
 
 private val QuackBottomSheetHandleSize = DpSize(
@@ -91,6 +91,7 @@ public fun QuackBottomSheet(
                 sheetContent = sheetContent,
             )
         },
+        sheetShape = BottomSheetShape,
         sheetBackgroundColor = QuackColor.Transparent.composeColor,
         sheetState = bottomSheetState,
         scrimColor = QuackColor.Black80.composeColor,
@@ -217,6 +218,7 @@ public fun QuackSubtitleBottomSheet(
         useHandle = true,
     )
 }
+
 /**
  * [QuackBottomSheetContent] 를 구현합니다.
  *
@@ -228,28 +230,23 @@ private fun QuackBottomSheetContent(
     useHandle: Boolean,
     sheetContent: @Composable () -> Unit,
 ) {
-
     Column(
-        modifier = Modifier.clip(
-                shape = BottomSheetShape
-            ),
-    ) {
-        Column(
-            modifier = Modifier
-                .applyQuackSize(
-                    width = QuackWidth.Fill,
-                    height = QuackHeight.Wrap,
-                ).background(
-                    color = QuackColor.White.composeColor,
-                ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            QuackBottomSheetHandle(
-                useHandle = useHandle,
+        modifier = Modifier
+            .applyQuackSize(
+                width = QuackWidth.Fill,
+                height = QuackHeight.Wrap,
             )
-            sheetContent()
-        }
+            .background(
+                color = QuackColor.White.composeColor,
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        QuackBottomSheetHandle(
+            useHandle = useHandle,
+        )
+        sheetContent()
     }
+
 }
 
 /**
@@ -259,7 +256,7 @@ private fun QuackBottomSheetContent(
  */
 @Composable
 private fun QuackBottomSheetHandle(
-    useHandle: Boolean
+    useHandle: Boolean,
 ) {
     Box(
         modifier = Modifier
@@ -313,12 +310,14 @@ private fun QuackBottomSheetSubtitleItem(
                 height = QuackHeight.Custom(
                     height = QuackBottomSheetSubtitleItemHeight,
                 ),
-            ).quackClickable(
+            )
+            .quackClickable(
                 onClick = {
                     onClick(item)
                 },
                 rippleEnabled = rippleEnabled,
-            ).padding(
+            )
+            .padding(
                 paddingValues = QuackBottomSheetStartPadding,
             ),
         contentAlignment = Alignment.CenterStart,
@@ -358,7 +357,7 @@ private fun QuackBottomSheetSubtitles(
  */
 @Composable
 private fun QuackBottomSheetHeadline(
-    headline: String
+    headline: String,
 ) {
     Box(
         modifier = Modifier.padding(

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/bottomSheet.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/bottomSheet.kt
@@ -201,7 +201,6 @@ public fun QuackSubtitleBottomSheet(
                         isImportant = false,
                     ),
                     onClick = onClick,
-                    rippleEnabled = false,
                 )
                 Divider(
                     modifier = Modifier.padding(
@@ -290,13 +289,11 @@ private fun QuackBottomSheetHandle(
  *
  * @param item Subtitle 의 아이템 데이터 값
  * @param onClick Subtitle 을 onClick 했을 떄 이벤트
- * @param rippleEnabled onClick 이벤트 발생시 ripple 이 발생하는지 여부
  */
 @Composable
 private fun QuackBottomSheetSubtitleItem(
     item: QuackBottomSheetItem,
     onClick: (QuackBottomSheetItem) -> Unit,
-    rippleEnabled: Boolean = true,
 ) {
     val textColor = when (item.isImportant) {
         true -> QuackColor.OrangeRed
@@ -315,7 +312,6 @@ private fun QuackBottomSheetSubtitleItem(
                 onClick = {
                     onClick(item)
                 },
-                rippleEnabled = rippleEnabled,
             )
             .padding(
                 paddingValues = QuackBottomSheetStartPadding,

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/image.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/image.kt
@@ -47,6 +47,7 @@ private val QuackRoundImageSize = DpSize(
  * @param tint 아이콘에 적용할 틴트 값
  * @param rippleEnabled 이미지 클릭시 ripple 발생 여부
  * @param onClick 아이콘이 클릭됐을 때 실행할 람다식
+ * @param contentScale 이미지에 들어갈 ContentScale 값
  */
 @Composable
 public fun QuackImage(
@@ -55,6 +56,7 @@ public fun QuackImage(
     tint: QuackColor? = null,
     rippleEnabled: Boolean = true,
     onClick: (() -> Unit)? = null,
+    contentScale: ContentScale = ContentScale.Crop,
 ): Unit = QuackImageInternal(
     modifier = Modifier.quackClickable(
         rippleEnabled = rippleEnabled,
@@ -63,6 +65,7 @@ public fun QuackImage(
     src = src,
     overrideSize = overrideSize,
     tint = tint,
+    contentScale = contentScale,
 )
 
 /**
@@ -98,6 +101,7 @@ public fun QuackRoundImage(
  * 만약 null 이 들어온다면 이미지를 그리지 않습니다.
  * @param overrideSize 리소스의 크기를 지정합니다. null 이 들어오면 기본 크기로 표시합니다.
  * @param tint 아이콘에 적용할 틴트 값
+ * @param contentScale 이미지에 들어갈 contentScale 값
  */
 // TODO: 로딩 effect
 @Composable
@@ -106,6 +110,7 @@ internal fun QuackImageInternal(
     src: Any?,
     overrideSize: DpSize? = null,
     tint: QuackColor? = null,
+    contentScale: ContentScale = ContentScale.Crop,
 ) {
     if (src == null) return
     val density = LocalDensity.current
@@ -130,7 +135,7 @@ internal fun QuackImageInternal(
                             id = imageModel.drawableId,
                         ),
                         colorFilter = animatedTint.toColorFilter(),
-                        contentScale = ContentScale.Fit,
+                        contentScale = contentScale,
                     )
             )
         }
@@ -173,7 +178,7 @@ internal fun QuackImageInternal(
                 .build(),
             colorFilter = animatedTint.toColorFilter(),
             contentDescription = null,
-            contentScale = ContentScale.Crop,
+            contentScale = contentScale,
         )
     }
 }


### PR DESCRIPTION
## Overview (Required)

- Bottom Sheet Radius 16dp로 수정했습니다
- sheetShape를 줘서 Radius이외의 영역을 clip하였습니다.
- image에서 contentScale을 인자로 받을 수 있게 수정하였습니다.
- QuackBottomSheetSubtitle을 항상 rippleEnabled로 수정했습니다

