### PR TITLE
chore: enabled gradle cache auto cleanup

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,12 @@ pluginManagement {
     }
 }
 
+buildCache {
+    local {
+        removeUnusedEntriesAfterDays = 7
+    }
+}
+
 include(
     ":playground",
     ":common-lint",


### PR DESCRIPTION
## Overview (Required)

- 7일동안 쓰이지 않은 그레이들 빌드 캐시는 자동 삭제하도록 설정하였습니다.